### PR TITLE
feat: Vlog or Blog 상태관리 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "styled-components": "^6.0.2",
         "styled-reset": "^4.5.1",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.4.1"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -17335,6 +17336,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18365,6 +18374,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "styled-components": "^6.0.2",
     "styled-reset": "^4.5.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.4.1"
   },
   "scripts": {
     "start": "craco start",

--- a/src/components/header/LeftHeader.tsx
+++ b/src/components/header/LeftHeader.tsx
@@ -1,14 +1,25 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
 // icon
 import { FiMenu } from 'react-icons/fi';
 
+/** 2023/08/18 - 헤더 왼쪽 컴포넌트 (메뉴바, 로고) - by sineTlsl */
 const LeftHeader = () => {
+  const navigate = useNavigate();
+
+  /** 2023/08/18 - 로고 클릭 시 메인페이지로 이동 - by sineTlsl */
+  const handlerGoMain = () => {
+    navigate('/');
+  };
+
   return (
     <LeftHeaderContainer>
       <StyledMenu color="var(--black-light)" />
       <div className="logo_wrap">
-        <img src="/assets/images/vblog_logo.png" />
+        <button onClick={handlerGoMain}>
+          <img src="/assets/images/vblog_logo.png" />
+        </button>
       </div>
     </LeftHeaderContainer>
   );
@@ -26,7 +37,15 @@ const LeftHeaderContainer = styled.div`
     position: relative;
     width: 170px;
     height: 65px;
-    > img {
+
+    > button {
+      border: none;
+      background: none;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
+    > button > img {
       object-fit: contain;
       width: 100%;
       height: 100%;

--- a/src/components/header/RightHeader.tsx
+++ b/src/components/header/RightHeader.tsx
@@ -1,15 +1,30 @@
 import styled from 'styled-components';
+import { useContentModeStore } from '@store/useConentModeStore';
 
 // icon
 import { HiOutlineSearch } from 'react-icons/hi';
 import { BiSolidDownArrow } from 'react-icons/bi';
 
+type ContentMode = 'V' | 'B';
+
+/** 2023/08/18 - 헤더 오른쪽 컴포넌트 (비로그인 or 로그인) - by sineTlsl */
 const RightHeader = () => {
+  const { mode, setMode } = useContentModeStore();
+
+  /** 2023/08/18 - Vlog or Blog 전환하는 함수 - by sineTlsl */
+  const handleContentMode = () => {
+    const newMode = mode === 'V' ? 'B' : 'V';
+
+    setMode(newMode);
+  };
+
   return (
     <RightHeaderContainer>
       <div className="btn_wrap">
         <StyledSearch color="var(--gray-dark)" />
-        <VblogChangeBtn>V</VblogChangeBtn>
+        <VblogChangeBtn mode={mode} onClick={handleContentMode}>
+          {mode}
+        </VblogChangeBtn>
       </div>
       <div className="gap" />
       <div className="profile-wrap">
@@ -58,17 +73,18 @@ const StyledSearch = styled(HiOutlineSearch)`
 `;
 
 // Vlog or Blog 전환 버튼
-const VblogChangeBtn = styled.button`
+const VblogChangeBtn = styled.button<{ mode: ContentMode }>`
   width: 30px;
   height: 30px;
-  background: var(--green-hunt);
+  background: ${({ mode }) => (mode === 'V' ? 'var(--green-hunt)' : 'var(--brown-hunt)')};
   border: none;
   border-radius: 3px;
-  color: var(--white-hunt);
+  color: ${({ mode }) => (mode === 'V' ? 'var(--white-hunt)' : 'var(--black-hunt)')};
   letter-spacing: -0.16px;
   font-size: 20px;
   font-weight: 700;
-  text-align: center;
+  cursor: pointer;
+  ${({ theme }) => theme.common.flexCenterRow};
 
   @media ${props => props.theme.breakpoints.mobileSMax} {
     width: 27px;

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -7,35 +7,43 @@ import RightHeader from '@components/header/RightHeader';
 const Header = () => {
   return (
     <HeaderContainer>
-      <LeftHeader />
-      <RightHeader />
+      <HeaderSpaceBetween>
+        <LeftHeader />
+        <RightHeader />
+      </HeaderSpaceBetween>
     </HeaderContainer>
   );
 };
 
 export default Header;
 
-// Header 컨테이너
 const HeaderContainer = styled.header`
-  margin: 0 auto;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
+  background: var(--white-deepdark);
+  z-index: 100;
+  width: 100%;
+  height: 65px;
+  border-bottom: 1px solid var(--gray-light);
+
+  @media ${props => props.theme.breakpoints.mobileSMax} {
+    height: 50px;
+  }
+`;
+
+const HeaderSpaceBetween = styled.div`
+  margin: 0 auto;
   display: flex;
   justify-content: space-between;
   align-items: center;
   max-width: ${({ theme }) => theme.widthSize.contentMax};
   width: 100%;
-  height: 65px;
-  background: var(--bg-white);
+  height: 100%;
   padding: 0 1.5rem;
-  border-bottom: 1px solid var(--gray-light);
-  z-index: 100;
 
   @media ${props => props.theme.breakpoints.mobileSMax} {
-    width: 100%;
-    height: 50px;
     padding: 0 1rem;
   }
 `;

--- a/src/store/useConentModeStore.ts
+++ b/src/store/useConentModeStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type ContentMode = 'V' | 'B';
+
+interface ContentModeStore {
+  mode: ContentMode;
+  setMode: (newMode: ContentMode) => void;
+}
+
+/** 2023/08/18 - Vlog or Blog 모드 선택하는 저장소 - by sineTlsl */
+const useContentModeStore = create(
+  persist<ContentModeStore>(
+    set => ({
+      mode: 'V',
+      setMode: newMode => set({ mode: newMode }),
+    }),
+    {
+      name: 'useContentModeStore',
+      getStorage: () => sessionStorage,
+    },
+  ),
+);
+
+export { useContentModeStore };

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -8,6 +8,7 @@
       "@pages/*": ["pages/*"],
       "@services/*": ["services/*"],
       "@styles/*": ["styles/*"],
+      "@store/*": ["store/*"],
       "@types/*": ["types/*"],
       "@utils/*": ["utils/*"]
     }


### PR DESCRIPTION
### Branch
`feat/header/#6` -> `dev`

### 변경사항
- 헤더에 `V` or `B` 상태 관리 추가
- 헤더 콘텐츠 너비 변경

### 유의사항
- zustand 상태관리 라이브러리 설치함으로 인해 새로 `npm install`

다음과 같이 V or B 모드 스토어를 불러서 사용할 수 있음
```ts
import { useContentModeStore } from '@store/useConentModeStore';

const { mode } = useContentModeStore();
```
